### PR TITLE
Minor fixes:

### DIFF
--- a/tests/ihex-to-img.py
+++ b/tests/ihex-to-img.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#! /usr/bin/env python3
 #
 # Copyright (c) Matthew Naylor
 #
@@ -9,10 +9,10 @@
 import sys
 
 def usage():
-  print "Usage: ihex-to-img.py <input.hex> <fmt> <base> <width> <depth> <inc>"
-  print ""
-  print "  <format> is either hex or mif"
-  print "  Units of <width> and <depth> are bytes"
+  print("Usage: ihex-to-img.py <input.hex> <fmt> <base> <width> <depth> <inc>")
+  print("")
+  print("  <format> is either hex or mif")
+  print("  Units of <width> and <depth> are bytes")
 
 if len(sys.argv) != 7:
   usage()
@@ -29,7 +29,7 @@ try:
   depth = int(sys.argv[5])
   inc = int(sys.argv[6])
 except:
-  print "Invalid parameters"
+  print("Invalid parameters")
   usage()
   sys.exit()
 
@@ -62,39 +62,39 @@ try:
     elif recType == "04":
       upperAddr = int(line[9:13], 16)
     else:
-      print "Record type", recType, "not supported"
+      print("Record type", recType, "not supported")
       sys.exit()
     lineCount = lineCount+1
 except:
-  print "Syntax error on line", lineCount
+  print("Syntax error on line", lineCount)
   sys.exit()
 
 # Print out memory contents
 if fmt == "mif":
   # Altera mif format
-  print "DEPTH =", (depth/width)/inc, ";"
-  print "WIDTH =", 8*width, ";"
-  print "ADDRESS_RADIX = DEC ;"
-  print "DATA_RADIX = HEX ;"
-  print "CONTENT"
-  print "BEGIN"
+  print("DEPTH =", (depth/width)/inc, ";")
+  print("WIDTH =", 8*width, ";")
+  print("ADDRESS_RADIX = DEC ;")
+  print("DATA_RADIX = HEX ;")
+  print("CONTENT")
+  print("BEGIN")
   byteList = []
   addr = base
   count = 0
   for i in range(base, base+depth, inc):
     byteList.insert(0, mem.get(i, "00"))
     if len(byteList) == width:
-      print count, ": ",
-      print "".join(byteList), ";"
+      print(count, ": ",)
+      print("".join(byteList), ";")
       byteList = []
       addr = addr + 1
       count = count + 1
-  print "END"
+  print("END")
 else:
   # Bluesim hex format
   byteList = []
   for i in range(base, base+depth, inc):
     byteList.insert(0, mem.get(i, "00"))
     if len(byteList) == width:
-      print "".join(byteList)
+      print("".join(byteList))
       byteList = []

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,7 +18,7 @@ for FILE in *.S; do
   cp $TEST.data.hex $SIM/data.hex
   pushd . > /dev/null
   cd $SIM
-  RESULT=$(./SimPebbles | head -n 1 | cut -d ' ' -f 2)
+  RESULT=$(./SimPebbles | head -n 1 | awk '{print $2}')
   popd > /dev/null
   if [ "$RESULT" == "0x00000001" ]; then
     echo "PASSED"


### PR DESCRIPTION
- On Ubuntu 20.04, only python3 by default ==> changed ihex-to-img.py to python3
- With Verilator 4.100, simulation seams to generate leading whitespaces before
  numeric values for alignment ... ? ==> Generalised run.sh using awk