### PR TITLE
Refactor coalescing unit

### DIFF
--- a/apps/Common/app.mk
+++ b/apps/Common/app.mk
@@ -56,12 +56,12 @@ link.ld: $(PEBBLES_ROOT)/apps/Common/link.ld.h
 	cpp -P -I $(PEBBLES_ROOT)/inc $< > link.ld
 
 Run: checkenv code.v data.v $(RUN_CPP) $(RUN_H)
-	gcc -std=c++11 -O2 -I $(PEBBLES_ROOT)/inc -o Run $(RUN_CPP) \
+	g++ -std=c++11 -O2 -I $(PEBBLES_ROOT)/inc -o Run $(RUN_CPP) \
     -fno-exceptions -ljtag_atlantic -ljtag_client \
     -L $(QUARTUS_ROOTDIR)/linux64/ -Wl,-rpath,$(QUARTUS_ROOTDIR)/linux64
 
 RunSim: code.v data.v $(RUN_CPP) $(RUN_H)
-	gcc -DSIMULATE -O2 -I $(PEBBLES_ROOT)/inc -o RunSim $(RUN_CPP)
+	g++ -DSIMULATE -O2 -I $(PEBBLES_ROOT)/inc -o RunSim $(RUN_CPP)
 
 # Raise error if QUARTUS_ROOTDIR not set
 .PHONY: checkenv

--- a/apps/MatVecMul/MatVecMul.cpp
+++ b/apps/MatVecMul/MatVecMul.cpp
@@ -42,8 +42,8 @@ int main()
   bool isSim = cpuUartBlockingGet();
 
   // Vector and matrix dimensions for benchmarking
-  int width = isSim ? 128 : 512;
-  int height = isSim ? 64 : 512;
+  int width = isSim ? 128 : 1024;
+  int height = isSim ? 64 : 1024;
 
   // Input and outputs
   simt_aligned int mat[height*width], vecIn[width], vecOut[height];

--- a/apps/TestSuite/Makefile
+++ b/apps/TestSuite/Makefile
@@ -64,20 +64,22 @@ link.ld: $(PEBBLES_ROOT)/apps/Common/link.ld.h
 	@$(RV_CC) -D_TEST_SIMT_ $(CFLAGS) -Wall -c -o $@ $<
 
 TestCPU: checkenv TestCPU.cpp
-	@gcc -std=c++11 -O2 -I $(PEBBLES_ROOT)/inc -o TestCPU TestCPU.cpp \
+	@g++ -std=c++11 -O2 -I $(PEBBLES_ROOT)/inc -o TestCPU TestCPU.cpp \
     -fno-exceptions -ljtag_atlantic -ljtag_client \
     -L $(QUARTUS_ROOTDIR)/linux64/ -Wl,-rpath,$(QUARTUS_ROOTDIR)/linux64
 
 TestCPUSim: TestCPU.cpp
-	@gcc -DSIMULATE -O2 -I $(PEBBLES_ROOT)/inc -o TestCPUSim TestCPU.cpp
+	@g++ -std=c++11 -DSIMULATE -O2 -I $(PEBBLES_ROOT)/inc \
+    -o TestCPUSim TestCPU.cpp
 
 TestSIMT: checkenv TestSIMT.cpp
-	@gcc -std=c++11 -O2 -I $(PEBBLES_ROOT)/inc -o TestSIMT TestSIMT.cpp \
+	@g++ -std=c++11 -O2 -I $(PEBBLES_ROOT)/inc -o TestSIMT TestSIMT.cpp \
     -fno-exceptions -ljtag_atlantic -ljtag_client \
     -L $(QUARTUS_ROOTDIR)/linux64/ -Wl,-rpath,$(QUARTUS_ROOTDIR)/linux64
 
 TestSIMTSim: TestSIMT.cpp
-	@gcc -DSIMULATE -O2 -I $(PEBBLES_ROOT)/inc -o TestSIMTSim TestSIMT.cpp
+	@g++ -std=c++11 -DSIMULATE -O2 -I $(PEBBLES_ROOT)/inc \
+    -o TestSIMTSim TestSIMT.cpp
 
 .PHONY: test-cpu
 test-cpu: v-files TestCPU

--- a/de10-pro/DE10_Pro.sdc
+++ b/de10-pro/DE10_Pro.sdc
@@ -14,11 +14,10 @@ create_clock -period 20 [get_ports CLK_50_B3C]
 create_clock -period 20 [get_ports CLK_50_B3I]
 create_clock -period 20 [get_ports CLK_50_B3L]
 
-create_clock -period "166.667 MHz" [get_ports DDR4A_REFCLK_p]
-create_clock -period "166.667 MHz" [get_ports DDR4B_REFCLK_p]
-create_clock -period "166.667 MHz" [get_ports DDR4C_REFCLK_p]
-create_clock -period "166.667 MHz" [get_ports DDR4D_REFCLK_p]
-
+create_clock -period "266.666666 MHz" [get_ports DDR4A_REFCLK_p]
+create_clock -period "166.666666 MHz" [get_ports DDR4B_REFCLK_p]
+create_clock -period "166.666666 MHz" [get_ports DDR4C_REFCLK_p]
+create_clock -period "166.666666 MHz" [get_ports DDR4D_REFCLK_p]
 
 #**************************************************************
 # Create Generated Clock

--- a/de10-pro/DE10_Pro.v
+++ b/de10-pro/DE10_Pro.v
@@ -11,6 +11,18 @@ module DE10_Pro(
   input [1:0] SW,
   output [3:0] LED,
 
+  inout SI5340A0_I2C_SCL,
+  inout SI5340A0_I2C_SDA,
+  input SI5340A0_INTR,
+  output SI5340A0_OE_n,
+  output SI5340A0_RST_n,
+
+  inout SI5340A1_I2C_SCL,
+  inout SI5340A1_I2C_SDA,
+  input SI5340A1_INTR,
+  output SI5340A1_OE_n,
+  output SI5340A1_RST_n,
+
   output FLASH_CLK,
   output [27:1] FLASH_A,
   inout [15:0] FLASH_D,
@@ -21,27 +33,27 @@ module DE10_Pro(
   output FLASH_RESET_n,
   input FLASH_RDY_BSY_n,
 
-  input DDR4A_REFCLK_p,
-  output [16:0] DDR4A_A,
-  output [1:0] DDR4A_BA,
-  output [1:0] DDR4A_BG,
-  output DDR4A_CK,
-  output DDR4A_CK_n,
-  output DDR4A_CKE,
-  inout [8:0] DDR4A_DQS,
-  inout [8:0] DDR4A_DQS_n,
-  inout [71:0] DDR4A_DQ,
-  inout [8:0] DDR4A_DBI_n,
-  output DDR4A_CS_n,
-  output DDR4A_RESET_n,
-  output DDR4A_ODT,
-  output DDR4A_PAR,
-  input DDR4A_ALERT_n,
-  output DDR4A_ACT_n,
-  input DDR4A_EVENT_n,
-  inout DDR4A_SCL,
-  inout DDR4A_SDA,
-  input DDR4A_RZQ,
+  input  DDR4B_REFCLK_p,
+  output [16:0] DDR4B_A,
+  output [1:0] DDR4B_BA,
+  output [1:0] DDR4B_BG,
+  output DDR4B_CK,
+  output DDR4B_CK_n,
+  output DDR4B_CKE,
+  inout  [8:0] DDR4B_DQS,
+  inout  [8:0] DDR4B_DQS_n,
+  inout  [71:0] DDR4B_DQ,
+  inout  [8:0] DDR4B_DBI_n,
+  output DDR4B_CS_n,
+  output DDR4B_RESET_n,
+  output DDR4B_ODT,
+  output DDR4B_PAR,
+  input DDR4B_ALERT_n,
+  output DDR4B_ACT_n,
+  input DDR4B_EVENT_n,
+  inout DDR4B_SCL,
+  inout DDR4B_SDA,
+  input DDR4B_RZQ,
 
   input EXP_EN,
 
@@ -52,9 +64,9 @@ module DE10_Pro(
 wire reset_n;
 wire ddr4_local_reset_req;
 
-wire ddr4_a_local_reset_done;
-wire ddr4_a_status_local_cal_fail;
-wire ddr4_a_status_local_cal_success;
+wire ddr4_b_local_reset_done;
+wire ddr4_b_status_local_cal_fail;
+wire ddr4_b_status_local_cal_success;
 
 wire [11:0] ddr4_status;
 
@@ -66,42 +78,40 @@ reset_release reset_release (
 
 assign reset_n = !ninit_done && CPU_RESET_n;
 assign ddr4_status =
-  {ddr4_a_status_local_cal_fail,
-     ddr4_a_status_local_cal_success,
-       ddr4_a_local_reset_done};
+  {ddr4_b_status_local_cal_fail,
+     ddr4_b_status_local_cal_success,
+       ddr4_b_local_reset_done};
 
 DE10_Pro_QSYS DE10_Pro_QSYS_inst (
-		.clk_clk(CLK_50_B3I),                                             
-		.reset_reset(~reset_n),                                          
+        .clk_clk(CLK_50_B3I),
+        .reset_reset(~reset_n),
+        .emif_s10_ddr4_b_mem_mem_ck(DDR4B_CK),                          
+        .emif_s10_ddr4_b_mem_mem_ck_n(DDR4B_CK_n),                        
+        .emif_s10_ddr4_b_mem_mem_a(DDR4B_A),                           
+        .emif_s10_ddr4_b_mem_mem_act_n(DDR4B_ACT_n),                       
+        .emif_s10_ddr4_b_mem_mem_ba(DDR4B_BA),                          
+        .emif_s10_ddr4_b_mem_mem_bg(DDR4B_BG),                          
+        .emif_s10_ddr4_b_mem_mem_cke(DDR4B_CKE),                         
+        .emif_s10_ddr4_b_mem_mem_cs_n(DDR4B_CS_n),                        
+        .emif_s10_ddr4_b_mem_mem_odt(DDR4B_ODT),                         
+        .emif_s10_ddr4_b_mem_mem_reset_n(DDR4B_RESET_n),                     
+        .emif_s10_ddr4_b_mem_mem_par(DDR4B_PAR),                         
+        .emif_s10_ddr4_b_mem_mem_alert_n(DDR4B_ALERT_n),                     
+        .emif_s10_ddr4_b_mem_mem_dqs(DDR4B_DQS),                         
+        .emif_s10_ddr4_b_mem_mem_dqs_n(DDR4B_DQS_n),                       
+        .emif_s10_ddr4_b_mem_mem_dq(DDR4B_DQ),                          
+        .emif_s10_ddr4_b_mem_mem_dbi_n(DDR4B_DBI_n),                       
+        .emif_s10_ddr4_b_oct_oct_rzqin(DDR4B_RZQ),                       
+        .emif_s10_ddr4_b_pll_ref_clk_clk(DDR4B_REFCLK_p),                     
+        .emif_s10_ddr4_b_status_local_cal_success(ddr4_b_status_local_cal_success),            
+        .emif_s10_ddr4_b_status_local_cal_fail(ddr4_b_status_local_cal_fail),   
+        .iopll_0_locked_export()
+    );
 
-		.iopll_0_locked_export(),                               
+assign SI5340A0_RST_n = 1'b1;
+assign SI5340A1_RST_n = 1'b1;
 
-		//.ddr4_local_reset_req_external_connection_export(ddr4_local_reset_req),
-		//.ddr4_status_external_connection_export(ddr4_status),
-		//.emif_s10_ddr4_a_local_reset_req_local_reset_req(ddr4_local_reset_req),
-		//.emif_s10_ddr4_a_local_reset_status_local_reset_done(
-    //    ddr4_a_local_reset_done), 
-
-		.emif_s10_ddr4_a_mem_mem_ck(DDR4A_CK),                          
-		.emif_s10_ddr4_a_mem_mem_ck_n(DDR4A_CK_n),                        
-		.emif_s10_ddr4_a_mem_mem_a(DDR4A_A),                           
-		.emif_s10_ddr4_a_mem_mem_act_n(DDR4A_ACT_n),                       
-		.emif_s10_ddr4_a_mem_mem_ba(DDR4A_BA),                          
-		.emif_s10_ddr4_a_mem_mem_bg(DDR4A_BG),                          
-		.emif_s10_ddr4_a_mem_mem_cke(DDR4A_CKE),                         
-		.emif_s10_ddr4_a_mem_mem_cs_n(DDR4A_CS_n),                        
-		.emif_s10_ddr4_a_mem_mem_odt(DDR4A_ODT),                         
-		.emif_s10_ddr4_a_mem_mem_reset_n(DDR4A_RESET_n),                     
-		.emif_s10_ddr4_a_mem_mem_par(DDR4A_PAR),                         
-		.emif_s10_ddr4_a_mem_mem_alert_n(DDR4A_ALERT_n),                     
-		.emif_s10_ddr4_a_mem_mem_dqs(DDR4A_DQS),                         
-		.emif_s10_ddr4_a_mem_mem_dqs_n(DDR4A_DQS_n),                       
-		.emif_s10_ddr4_a_mem_mem_dq(DDR4A_DQ),                          
-		.emif_s10_ddr4_a_mem_mem_dbi_n(DDR4A_DBI_n),                       
-		.emif_s10_ddr4_a_oct_oct_rzqin(DDR4A_RZQ),                       
-		.emif_s10_ddr4_a_pll_ref_clk_clk(DDR4A_REFCLK_p),                     
-		.emif_s10_ddr4_a_status_local_cal_success(ddr4_a_status_local_cal_success),
-		.emif_s10_ddr4_a_status_local_cal_fail(ddr4_a_status_local_cal_fail)
-	);
+assign SI5340A0_OE_n = 1'b0;
+assign SI5340A1_OE_n = 1'b0;
 
 endmodule

--- a/de10-pro/DE10_Pro_QSYS.qsys
+++ b/de10-pro/DE10_Pro_QSYS.qsys
@@ -96,7 +96,7 @@
       }
       datum baseAddress
       {
-         value = "4294967296";
+         value = "0";
          type = "String";
       }
    }
@@ -242,46 +242,46 @@
    internal="ddr4_status.external_connection" />
  <interface
    name="emif_s10_ddr4_a_local_reset_req"
-   internal="emif_s10_ddr4_a.local_reset_req"
-   type="conduit"
-   dir="end" />
+   internal="emif_s10_ddr4_a.local_reset_req" />
  <interface
    name="emif_s10_ddr4_a_local_reset_status"
-   internal="emif_s10_ddr4_a.local_reset_status"
-   type="conduit"
-   dir="end" />
- <interface
-   name="emif_s10_ddr4_a_mem"
-   internal="emif_s10_ddr4_a.mem"
-   type="conduit"
-   dir="end" />
- <interface
-   name="emif_s10_ddr4_a_oct"
-   internal="emif_s10_ddr4_a.oct"
-   type="conduit"
-   dir="end" />
+   internal="emif_s10_ddr4_a.local_reset_status" />
+ <interface name="emif_s10_ddr4_a_mem" internal="emif_s10_ddr4_a.mem" />
+ <interface name="emif_s10_ddr4_a_oct" internal="emif_s10_ddr4_a.oct" />
  <interface
    name="emif_s10_ddr4_a_pll_ref_clk"
-   internal="emif_s10_ddr4_a.pll_ref_clk"
+   internal="emif_s10_ddr4_a.pll_ref_clk" />
+ <interface name="emif_s10_ddr4_a_status" internal="emif_s10_ddr4_a.status" />
+ <interface
+   name="emif_s10_ddr4_b_local_reset_req"
+   internal="emif_s10_ddr4_b.local_reset_req"
+   type="conduit"
+   dir="end" />
+ <interface
+   name="emif_s10_ddr4_b_local_reset_status"
+   internal="emif_s10_ddr4_b.local_reset_status"
+   type="conduit"
+   dir="end" />
+ <interface
+   name="emif_s10_ddr4_b_mem"
+   internal="emif_s10_ddr4_b.mem"
+   type="conduit"
+   dir="end" />
+ <interface
+   name="emif_s10_ddr4_b_oct"
+   internal="emif_s10_ddr4_b.oct"
+   type="conduit"
+   dir="end" />
+ <interface
+   name="emif_s10_ddr4_b_pll_ref_clk"
+   internal="emif_s10_ddr4_b.pll_ref_clk"
    type="clock"
    dir="end" />
  <interface
-   name="emif_s10_ddr4_a_status"
-   internal="emif_s10_ddr4_a.status"
+   name="emif_s10_ddr4_b_status"
+   internal="emif_s10_ddr4_b.status"
    type="conduit"
    dir="end" />
- <interface
-   name="emif_s10_ddr4_b_local_reset_req"
-   internal="emif_s10_ddr4_b.local_reset_req" />
- <interface
-   name="emif_s10_ddr4_b_local_reset_status"
-   internal="emif_s10_ddr4_b.local_reset_status" />
- <interface name="emif_s10_ddr4_b_mem" internal="emif_s10_ddr4_b.mem" />
- <interface name="emif_s10_ddr4_b_oct" internal="emif_s10_ddr4_b.oct" />
- <interface
-   name="emif_s10_ddr4_b_pll_ref_clk"
-   internal="emif_s10_ddr4_b.pll_ref_clk" />
- <interface name="emif_s10_ddr4_b_status" internal="emif_s10_ddr4_b.status" />
  <interface
    name="emif_s10_ddr4_c_local_reset_req"
    internal="emif_s10_ddr4_c.local_reset_req" />
@@ -3701,7 +3701,7 @@
    name="emif_s10_ddr4_a"
    kind="altera_generic_component"
    version="1.0"
-   enabled="1">
+   enabled="0">
   <parameter name="componentDefinition"><![CDATA[<componentDefinition>
     <boundary>
         <interfaces>
@@ -5241,7 +5241,7 @@
    name="emif_s10_ddr4_b"
    kind="altera_generic_component"
    version="1.0"
-   enabled="0">
+   enabled="1">
   <parameter name="componentDefinition"><![CDATA[<componentDefinition>
     <boundary>
         <interfaces>
@@ -13447,7 +13447,7 @@
                     <consumedSystemInfos>
                         <entry>
                             <key>ADDRESS_WIDTH</key>
-                            <value>10</value>
+                            <value>32</value>
                         </entry>
                     </consumedSystemInfos>
                 </value>
@@ -14456,7 +14456,7 @@
    kind="avalon"
    version="19.2"
    start="mm_clockcross_DDR4.m0"
-   end="emif_s10_ddr4_a.ctrl_amm_0">
+   end="emif_s10_ddr4_b.ctrl_amm_0">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x0000" />
   <parameter name="defaultConnection" value="false" />
@@ -14535,7 +14535,7 @@
  <connection
    kind="clock"
    version="19.2"
-   start="emif_s10_ddr4_a.emif_usr_clk"
+   start="emif_s10_ddr4_b.emif_usr_clk"
    end="mm_clockcross_DDR4.m0_clk" />
  <connection
    kind="clock"
@@ -14585,32 +14585,32 @@
  <connection
    kind="reset"
    version="19.2"
-   start="emif_s10_ddr4_a.emif_usr_reset_n"
-   end="mm_clockcross_DDR4.m0_reset" />
- <connection
-   kind="reset"
-   version="19.2"
-   start="emif_s10_ddr4_a.emif_usr_reset_n"
+   start="emif_s10_ddr4_b.emif_usr_reset_n"
    end="mm_clockcross_50Mhz.m0_reset" />
  <connection
    kind="reset"
    version="19.2"
-   start="emif_s10_ddr4_a.emif_usr_reset_n"
-   end="jtag_uart_0.reset" />
+   start="emif_s10_ddr4_b.emif_usr_reset_n"
+   end="mm_clockcross_DDR4.m0_reset" />
  <connection
    kind="reset"
    version="19.2"
-   start="emif_s10_ddr4_a.emif_usr_reset_n"
+   start="emif_s10_ddr4_b.emif_usr_reset_n"
    end="Pebbles_0.reset" />
  <connection
    kind="reset"
    version="19.2"
-   start="emif_s10_ddr4_a.emif_usr_reset_n"
+   start="emif_s10_ddr4_b.emif_usr_reset_n"
+   end="jtag_uart_0.reset" />
+ <connection
+   kind="reset"
+   version="19.2"
+   start="emif_s10_ddr4_b.emif_usr_reset_n"
    end="mm_clockcross_50Mhz.s0_reset" />
  <connection
    kind="reset"
    version="19.2"
-   start="emif_s10_ddr4_a.emif_usr_reset_n"
+   start="emif_s10_ddr4_b.emif_usr_reset_n"
    end="mm_clockcross_DDR4.s0_reset" />
  <connection
    kind="reset"

--- a/inc/SoC.h
+++ b/inc/SoC.h
@@ -44,6 +44,9 @@ NOTE("Size of each SRAM bank (in words)")
 NOTE("Enable SIMT stat counters")
 #define SIMTEnableStatCounters 1
 
+NOTE("Size of SRAM multicast id in coalescing unit")
+#define SIMTMcastIdSize 4
+
 NOTE("CPU configuration")
 NOTE("=================")
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ BUILD_DIR = $(PEBBLES_ROOT)/src/build
 
 .PHONY: all
 all:
-	$(BLC) $(BLC_FLAGS) -I$(BLC_INC) \
+	$(BLC) -fno-cpr-anal $(BLC_FLAGS) -I$(BLC_INC) \
     -hidir $(BUILD_DIR) -odir $(BUILD_DIR) Main.hs -o Main
 	./Main
 

--- a/src/Pebbles/Memory/CoalescingUnit.hs
+++ b/src/Pebbles/Memory/CoalescingUnit.hs
@@ -12,12 +12,14 @@ import Blarney
 import Blarney.Queue
 import Blarney.Stream
 import Blarney.SourceSink
+import Blarney.Interconnect
 import qualified Blarney.Vector as V
 
 -- Pebbles imports
 import Pebbles.Util.List
 import Pebbles.Memory.Interface
 import Pebbles.Memory.Alignment
+import Pebbles.Memory.BankedSRAMs
 import Pebbles.SoC.DRAM.Interface
 
 -- Haskell imports
@@ -34,39 +36,50 @@ type DRAMReqId = ()
 -- | Info for inflight DRAM requests (internal to this module)
 data CoalescingInfo t_id =
   CoalescingInfo {
-    -- | Use the SameBlock stategy?  (Otherwise, use SameAddress strategy)
     coalInfoUseSameBlock :: Bit 1
-    -- | Coalescing mask (lanes participating in coalesced access)
+    -- ^ Use the SameBlock stategy?  (Otherwise, use SameAddress strategy)
   , coalInfoMask :: Bit SIMTLanes
-    -- | Request id for each lane
+    -- ^ Coalescing mask (lanes participating in coalesced access)
   , coalInfoReqIds :: V.Vec SIMTLanes t_id
-    -- | Mode for SameBlock strategy
+    -- ^ Request id for each lane
   , coalInfoSameBlockMode :: Bit 2
-    -- | Lower bits of address
+    -- ^ Mode for SameBlock strategy
   , coalInfoAddr :: Bit DRAMBeatLogBytes
-    -- | Burst length
+    -- ^ Lower bits of address
   , coalInfoBurstLen :: DRAMBurst
+    -- ^ Burst length
   } deriving (Generic, Bits)
+
+-- | SRAM bank request info
+data BankInfo t_id =
+  BankInfo {
+    bankReqId :: t_id
+    -- ^ Request id
+  , bankLaneId :: Bit SIMTLogLanes
+    -- ^ Id of issuing lane
+  , bankMulticastResp :: Bit 1
+    -- ^ Response should be multicast to multiple lanes
+  }
+  deriving (Generic, Bits)
 
 -- Implementation
 -- ==============
 
 -- | The coalescing unit takes memory requests from multiple SIMT
--- lanes and coalesces them where possible into a single DRAM request
+-- lanes and coalesces them where possible into a single memory request
 -- using two strategies: (1) SameBlock: multiple accesses to the same
 -- DRAM block, where the lower bits of each address equal the SIMT
 -- lane id, are satisfied by a single DRAM burst; (2) SameAddress:
 -- mutliple accesses to the same address are satisifed by a single
--- DRAM access. The second strategy (which always makes progress)
--- is used if the first fails.  We employ a seven stage pipeline:
+-- DRAM/SRAM access. We employ a seven stage pipeline:
 --
 --   0. Consume requests and feed pipeline
 --   1. Pick one SIMT lane as a leader 
 --   2. Determine the leader's request with a mux
 --   3. Evaluate coalescing strategies
 --   4. Choose coalescing strategy and feed back unsatisifed reqs to stage 1
---   5. Issue DRAM requests
---   6. Consume DRAM responses and issue load responses
+--   5. Issue DRAM/SRAM requests
+--   6. Consume DRAM/SRAM responses and issue load responses
 --
 -- Notes:
 --   * The number of SIMT lanes is assumed to be equal to the
@@ -78,13 +91,15 @@ data CoalescingInfo t_id =
 --     ignored but the response signifies that all preceeding stores
 --     have reached DRAM).
 makeCoalescingUnit :: Bits t_id =>
-     -- | Stream of memory requests per lane
-     [Stream (MemReq t_id)]
-     -- | Responses from DRAM
+     (MemReq t_id -> Bit 1)
+     -- ^ Predicate to determine if request is for SRAM (true) or DRAM (false)
+  -> [Stream (MemReq t_id)]
+     -- ^ Stream of memory requests per lane
   -> Stream (DRAMResp DRAMReqId)
-     -- | Outputs: memory responses per lane and a stream of DRAM requests
+     -- ^ Responses from DRAM
   -> Module ([Stream (MemResp t_id)], Stream (DRAMReq DRAMReqId))
-makeCoalescingUnit memReqs dramResps = do
+     -- ^ Outputs: memory responses per lane and a stream of DRAM requests
+makeCoalescingUnit isBankedSRAMAccess memReqs dramResps = do
   -- Assumptions
   staticAssert (SIMTLanes == DRAMBeatHalfs)
     ("Coalescing Unit: number of SIMT lanes must equal " ++
@@ -95,14 +110,16 @@ makeCoalescingUnit memReqs dramResps = do
   go2 :: Reg (Bit 1) <- makeDReg false
   go3 :: Reg (Bit 1) <- makeDReg false
   go4 :: Reg (Bit 1) <- makeDReg false
-  go5 :: Reg (Bit 1) <- makeReg false
+  go5DRAM :: Reg (Bit 1) <- makeReg false
+  go5SRAM :: Reg (Bit 1) <- makeReg false
 
   -- Requests for each pipeline stage
   memReqs1 :: [Reg (MemReq t_id)] <- replicateM SIMTLanes (makeReg dontCare)
   memReqs2 :: [Reg (MemReq t_id)] <- replicateM SIMTLanes (makeReg dontCare)
   memReqs3 :: [Reg (MemReq t_id)] <- replicateM SIMTLanes (makeReg dontCare)
   memReqs4 :: [Reg (MemReq t_id)] <- replicateM SIMTLanes (makeReg dontCare)
-  memReqs5 :: [Reg (MemReq t_id)] <- replicateM SIMTLanes (makeReg dontCare)
+  memReqs5DRAM :: [Reg (MemReq t_id)] <- replicateM SIMTLanes (makeReg dontCare)
+  memReqs5SRAM :: [Reg (MemReq t_id)] <- replicateM SIMTLanes (makeReg dontCare)
 
   -- Pending request mask for each pipeline stage
   pending1 :: Reg (Bit SIMTLanes) <- makeReg dontCare
@@ -119,18 +136,19 @@ makeCoalescingUnit memReqs dramResps = do
   leader2 :: Reg (Bit SIMTLanes) <- makeReg 0
   leader3 :: Reg (Bit SIMTLanes) <- makeReg 0
   leader4 :: Reg (Bit SIMTLanes) <- makeReg 0
+  leader5SRAM :: Reg (Bit SIMTLanes) <- makeReg 0
 
   -- DRAM request queue
   dramReqQueue :: Queue (DRAMReq DRAMReqId) <- makePipelineQueue 1
 
-  -- Inflight requests
+  -- Inflight DRAM requests
   inflightQueue :: Queue (CoalescingInfo t_id) <-
     makeSizedQueue DRAMLogMaxInFlight
 
-  -- Response queues
+  -- DRAM response queues
   -- There's a lot of logic feeding these queues, so let's use a
   -- multi-level shift queue
-  respQueues :: [Queue (MemResp t_id)] <-
+  dramRespQueues :: [Queue (MemResp t_id)] <-
     replicateM SIMTLanes (makeShiftQueue 2)
 
   -- Stage 0: consume requests and feed pipeline
@@ -173,13 +191,6 @@ makeCoalescingUnit memReqs dramResps = do
     when (go1.val .&. stallWire.val.inv) do
       -- Select first pending request as leader
       leader2 <== pending1.val .&. (pending1.val.inv + 1)
-      -- Check that atomics are not in use
-      sequence_
-        [ do dynamicAssert (req.memReqOp .!=. memAtomicOp)
-               "Atomics not yet supported by CoalescingUnit"
-             dynamicAssert (req.memReqOp .!=. memLocalFenceOp)
-               "Local fence not supported by CoalescingUnit"
-        | req <- map val memReqs1 ]
       -- Trigger stage 2
       go2 <== true
       zipWithM_ (<==) memReqs2 (map val memReqs1)
@@ -209,6 +220,9 @@ makeCoalescingUnit memReqs dramResps = do
   sameBlockMode4 :: Reg (Bit 2) <- makeReg dontCare
   sameBlockMask4 :: Reg (Bit SIMTLanes) <- makeReg dontCare
   sameAddrMask4  :: Reg (Bit SIMTLanes) <- makeReg dontCare
+  sramMask4      :: Reg (Bit SIMTLanes) <- makeReg dontCare
+  sramAllLoads4  :: Reg (Bit 1) <- makeReg dontCare
+  isSRAMAccess4  :: Reg (Bit 1) <- makeReg dontCare
 
   always do
     -- Which requests can be satisfied by SameBlock strategy?
@@ -266,6 +280,11 @@ makeCoalescingUnit memReqs dramResps = do
               .&. (r.memReqAccessWidth .==. leaderReq3.val.memReqAccessWidth)
           | (p, r) <- zip (pending3.val.toBitList) (map val memReqs3) ]
 
+    -- Requests destined for banked SRAMs
+    let sramMask = 
+          [ p .&. isBankedSRAMAccess r
+          | (p, r) <- zip (pending3.val.toBitList) (map val memReqs3) ]
+
     -- State update
     when (go3.val .&. stallWire.val.inv) do
       -- SameAddress strategy should at least allow the leader to progress
@@ -290,6 +309,12 @@ makeCoalescingUnit memReqs dramResps = do
             else do
               sameBlockMode4 <== 0
               sameBlockMask4 <== byteModeMask
+      -- Is leader accessing banked SRAMs?
+      isSRAMAccess4 <== leaderReq3.val.isBankedSRAMAccess
+      sramMask4 <== fromBitList sramMask
+      sramAllLoads4 <== andList 
+        [ b .==. (req.memReqOp .==. memLoadOp)
+        | (b, req) <- zip sramMask (map val memReqs3) ]
       -- Trigger stage 4
       go4 <== true
       zipWithM_ (<==) memReqs4 (map val memReqs3)
@@ -309,6 +334,12 @@ makeCoalescingUnit memReqs dramResps = do
   -- Which lanes are participating in the strategy
   coalMask :: Reg (Bit SIMTLanes) <- makeReg dontCare
 
+  -- Use SameAddress strategy on SRAM path
+  useSameAddrSRAM :: Reg (Bit 1) <- makeReg dontCare
+
+  -- Which lanes have requests for SRAM
+  sramMask5 :: Reg (Bit SIMTLanes) <- makeReg dontCare
+
   always do
     -- Use SameBlock strategy if it satisfies leader's request and at
     -- least one other request.  Otherwise use SameAddr strategy,
@@ -317,23 +348,42 @@ makeCoalescingUnit memReqs dramResps = do
           ((sameBlockMask4.val .&. leader3.val) .==. leader3.val) .&.
             ((sameBlockMask4.val .&. leader3.val.inv) .!=. 0)
     -- Requests participating in strategy
-    let mask = useSameBlock ? (sameBlockMask4.val, sameAddrMask4.val)
+    let mask = isSRAMAccess4.val ? (sramMask4.val,
+                 useSameBlock ? (sameBlockMask4.val, sameAddrMask4.val))
     -- Try to trigger next stage
     when (go4.val) do
+      let busy = isSRAMAccess4.val ? (go5SRAM.val, go5DRAM.val)
       -- Check if stage 5 is currently busy
-      if go5.val
+      if busy
         then do
           -- If so, stall pipeline
           stallWire <== true
         else do
           -- Otherwise, setup and trigger next stage
-          go5 <== true
-          coalSameBlockStrategy <== useSameBlock
-          coalSameBlockMode <== sameBlockMode4.val
-          coalMask <== mask
-          leaderReq5 <== leaderReq4.val
-          forM_ (zip memReqs4 memReqs5) \(r4, r5) -> do
-            r5 <== r4.val
+          if isSRAMAccess4.val
+            then do
+              go5SRAM <== true
+              sramMask5 <== sramMask4.val
+              leader5SRAM <== leader4.val
+              forM_ (zip memReqs4 memReqs5SRAM) \(r4, r5) -> do
+                r5 <== r4.val
+              -- Use same address strategy if all SRAM accesses are
+              -- loads to the same address
+              useSameAddrSRAM <== sramAllLoads4.val .&&.
+                sramMask4.val .==. sameAddrMask4.val
+            else do
+              go5DRAM <== true
+              coalSameBlockStrategy <== useSameBlock
+              coalSameBlockMode <== sameBlockMode4.val
+              coalMask <== mask
+              leaderReq5 <== leaderReq4.val
+              forM_ (zip memReqs4 memReqs5DRAM) \(r4, r5) -> do
+                r5 <== r4.val
+              -- Check that atomics are not in use
+              dynamicAssert (leaderReq4.val.memReqOp .!=. memAtomicOp)
+                "Atomics not yet supported on DRAM path"
+              dynamicAssert (leaderReq4.val.memReqOp .!=. memLocalFenceOp)
+                "Local fence not supported on DRAM path"
           -- Determine any remaining pending requests
           let remaining = pending4.val .&. inv mask
           -- If there are any, feed them back
@@ -343,8 +393,8 @@ makeCoalescingUnit memReqs dramResps = do
             zipWithM_ (<==) memReqs1 (map val memReqs4)
             pending1 <== remaining
 
-  -- Stage 5: Issue DRAM requests
-  -- ============================
+  -- Stage 5 (DRAM): Issue DRAM requests
+  -- ===================================
 
   -- Count register for burst store
   storeCount :: Reg DRAMBurst <- makeReg 0
@@ -373,14 +423,14 @@ makeCoalescingUnit memReqs dramResps = do
                slice @15 @8 (r2.val.memReqData),
                slice @23 @16 (r3.val.memReqData),
                slice @31 @24 (r4.val.memReqData)]
-            | [r1, r2, r3, r4] <- groupsOf 4 memReqs5]
+            | [r1, r2, r3, r4] <- groupsOf 4 memReqs5DRAM]
     let sameBlockData16 :: V.Vec DRAMBeatHalfs (Bit 16) =
           V.fromList $ concat $
             [ [r1.val.memReqData.lower, r2.val.memReqData.upper]
-            | [r1, r2] <- groupsOf 2 memReqs5 ]
+            | [r1, r2] <- groupsOf 2 memReqs5DRAM ]
     let sameBlockData32 :: V.Vec DRAMBeatWords (Bit 32) =
           V.fromList $ selectHalf (storeCount.val.truncate)
-            [r.val.memReqData | r <- memReqs5]
+            [r.val.memReqData | r <- memReqs5DRAM]
     let sameBlockData :: DRAMBeat =
           [pack sameBlockData8,
              pack sameBlockData16,
@@ -404,7 +454,7 @@ makeCoalescingUnit memReqs dramResps = do
                   genByteEnable
                     (r.val.memReqAccessWidth)
                     (r.val.memReqAddr)
-              | (en, r) <- zip (mask.toBitList) memReqs5 ]
+              | (en, r) <- zip (mask.toBitList) memReqs5DRAM ]
     let sameBlockBE = [sameBlockBE8, sameBlockBE16, sameBlockBE32] !
            sameBlockMode
     -- DRAM byte enable field for SameAddress strategy
@@ -426,7 +476,7 @@ makeCoalescingUnit memReqs dramResps = do
           , dramReqBurst = burstLen
           }
     -- Try to issue DRAM request
-    when (go5.val) do
+    when (go5DRAM.val) do
       -- Check that we can make a DRAM request
       when (inflightQueue.notFull .&. dramReqQueue.notFull) do
         -- Issue DRAM request
@@ -436,7 +486,7 @@ makeCoalescingUnit memReqs dramResps = do
               CoalescingInfo {
                 coalInfoUseSameBlock = useSameBlock
               , coalInfoMask = mask
-              , coalInfoReqIds = V.fromList [r.val.memReqId | r <- memReqs5]
+              , coalInfoReqIds = V.fromList [r.val.memReqId | r <- memReqs5DRAM]
               , coalInfoSameBlockMode = sameBlockMode
               , coalInfoAddr = leaderReq5.val.memReqAddr.truncate
               , coalInfoBurstLen = burstLen - 1
@@ -446,19 +496,80 @@ makeCoalescingUnit memReqs dramResps = do
                         .||. leaderReq5.val.memReqOp .==. memGlobalFenceOp
         when hasResp do
           enq inflightQueue info
-          go5 <== false
+          go5DRAM <== false
         -- Handle store: increment burst count
         when (leaderReq5.val.memReqOp .==. memStoreOp) do
           let newStoreCount = storeCount.val + 1
           if newStoreCount .==. burstLen
             then do
               storeCount <== 0
-              go5 <== false
+              go5DRAM <== false
             else do
               storeCount <== newStoreCount
 
-  -- Stage 6: Handle DRAM responses
-  -- ==============================
+  -- Stage 5 (SRAM): Issue SRAM requests
+  -- ===================================
+
+  -- Multicast queue for SameAddress strategy on SRAM, i.e. a queue of
+  -- bit vectors denoting lanes that wish to receive each response
+  let sramMcastQueueLogSize = 5
+  sramMulticastQueue :: Queue (Bit SIMTLanes) <-
+    makeSizedQueue sramMcastQueueLogSize
+
+  -- Wires indicating when SRAM requests have been consumed
+  sramConsumeWires <- replicateM SIMTLanes (makeWire false)
+
+  -- Request stream per SRAM bank
+  let sramReqs = 
+        [ Source {
+            -- For SameAddress strategy, only the leader makes a request
+            canPeek = go5SRAM.val .&&.
+                        (useSameAddrSRAM.val ?
+                          (isLeader .&&. sramMulticastQueue.notFull, valid))
+          , peek = req {
+              memReqId =
+                BankInfo {
+                  bankReqId = req.memReqId
+                  -- When using the SameAddress strategy, arrange for
+                  -- the response to come back via lane 0
+                , bankLaneId = useSameAddrSRAM.val ? (0, fromInteger i)
+                  -- For SameAddress strategy, mark a multicast response
+                , bankMulticastResp = useSameAddrSRAM.val
+                }
+            }
+          , consume = consumeWire <== true
+          }
+        | (req, valid, consumeWire, isLeader, i) <-
+            zip5 (map val memReqs5SRAM)
+                 (sramMask5.val.toBitList)
+                 sramConsumeWires
+                 (leader5SRAM.val.toBitList)
+                 [0..]
+        ]
+
+  -- Instantiate banked SRAMs
+  let sramRoute info = info.bankLaneId
+  sramResps <- makeBankedSRAMs sramRoute sramReqs
+
+  always do
+    when (go5SRAM.val) do
+      -- Bit vector of streams being consumed
+      let sramConsumeVec :: Bit SIMTLanes = fromBitList
+            (map val sramConsumeWires)
+      -- Remove consumed requests from bit mask
+      sramMask5 <== sramMask5.val .&. inv sramConsumeVec
+      -- Have all requests been consumed?
+      let done = useSameAddrSRAM.val ?
+                   (sramConsumeVec .==. leader5SRAM.val,
+                    sramConsumeVec .==. sramMask5.val)
+      when (done) do
+        go5SRAM <== false
+        -- Record multicast response in queue
+        when (useSameAddrSRAM.val) do
+          enq sramMulticastQueue (sramMask5.val)
+
+  -- Stage 6 (DRAM): Handle responses
+  -- ================================
 
   -- Count register for burst load
   loadCount :: Reg DRAMBurst <- makeReg 0
@@ -489,7 +600,7 @@ makeCoalescingUnit memReqs dramResps = do
     -- Are needed response queues ready?
     let respQueuesReady =
           andList [ active .<=. q.notFull
-                  | (active, q) <- zip activeAny respQueues
+                  | (active, q) <- zip activeAny dramRespQueues
                   ]
     -- Determine items of data response
     let beatBytes :: V.Vec DRAMBeatBytes (Bit 8) = unpack (resp.dramRespData)
@@ -527,7 +638,7 @@ makeCoalescingUnit memReqs dramResps = do
           loadCount <== loadCount.val + 1
 
       -- Response info for each SIMT lane
-      let respInfo = zip4 respQueues activeAny
+      let respInfo = zip4 dramRespQueues activeAny
                           (V.toList (info.coalInfoReqIds))
                           (V.toList sameBlockData)
 
@@ -537,4 +648,46 @@ makeCoalescingUnit memReqs dramResps = do
           let respData = useSameBlock ? (d, sameAddrData)
           enq respQueue (MemResp id respData)
 
-  return (map toStream respQueues, toStream dramReqQueue)
+  -- Stage 6 (SRAM): Handle responses
+  -- ================================
+
+  -- SRAM response queues
+  sramRespQueues :: [Queue (MemResp t_id)] <-
+    replicateM SIMTLanes (makeShiftQueue 1)
+
+  always do
+    -- Helper to drop bank info from SRAM response id
+    let untag resp = resp { memRespId = resp.memRespId.bankReqId }
+
+    -- Look for multicast responses (which always return via lane 0)
+    -- that need to be delivered to multiple lanes
+    let respStream0 = sramResps.head
+    let resp0 = respStream0.peek
+    when (sramMulticastQueue.canDeq .&&.
+            respStream0.canPeek .&&.
+              resp0.memRespId.bankMulticastResp) do
+      let mcastMask = sramMulticastQueue.first
+      let guardedQueues = zip (mcastMask.toBitList) sramRespQueues
+      -- Check that all receivers are ready
+      let allReady = andList [g .==>. q.notFull | (g, q) <- guardedQueues]
+      when allReady do
+        sramMulticastQueue.deq
+        sequence_ [ when g do
+                      enq q (respStream0.peek.untag)
+                      respStream0.consume
+                  | (g, q) <- guardedQueues ]
+
+    -- Handle non-multicast responses
+    when (respStream0.canPeek .==>. resp0.memRespId.bankMulticastResp.inv) do
+      sequence_ [ when (s.canPeek .&&. q.notFull) do
+                    enq q (s.peek.untag)
+                    s.consume
+                | (s, q) <- zip sramResps sramRespQueues ]
+
+  -- Merge SRAM and DRAM responses
+  finalResps <- sequence
+    [ makeGenericFairMergeTwo (makePipelineQueue 1) (const true)
+       (toStream q0, toStream q1)
+    | (q0, q1) <- zip dramRespQueues sramRespQueues ]
+
+  return (finalResps, toStream dramReqQueue)

--- a/src/Pebbles/Memory/CoalescingUnit.hs
+++ b/src/Pebbles/Memory/CoalescingUnit.hs
@@ -313,7 +313,7 @@ makeCoalescingUnit isBankedSRAMAccess memReqs dramResps = do
       isSRAMAccess4 <== leaderReq3.val.isBankedSRAMAccess
       sramMask4 <== fromBitList sramMask
       sramAllLoads4 <== andList 
-        [ b .==. (req.memReqOp .==. memLoadOp)
+        [ b .==>. (req.memReqOp .==. memLoadOp)
         | (b, req) <- zip sramMask (map val memReqs3) ]
       -- Trigger stage 4
       go4 <== true

--- a/src/Pebbles/Memory/CoalescingUnit.hs
+++ b/src/Pebbles/Memory/CoalescingUnit.hs
@@ -370,7 +370,8 @@ makeCoalescingUnit isBankedSRAMAccess memReqs dramResps = do
               -- Use same address strategy if all SRAM accesses are
               -- loads to the same address
               useSameAddrSRAM <== sramAllLoads4.val .&&.
-                sramMask4.val .==. sameAddrMask4.val
+                sramMask4.val .==. ones .&&.
+                  sameAddrMask4.val .==. ones
             else do
               go5DRAM <== true
               coalSameBlockStrategy <== useSameBlock

--- a/src/Pebbles/Pipeline/SIMT.hs
+++ b/src/Pebbles/Pipeline/SIMT.hs
@@ -495,8 +495,8 @@ makeSIMTPipeline c inputs =
               store stateMem (warpId5.val)
                 SIMTThreadState {
                     -- Only update PC if not retrying
-                    simtPC = retryWire.val.inv ?
-                      (pcNextWire.val, state5.val.simtPC)
+                    simtPC = retryWire.val ?
+                      (state5.val.simtPC, pcNextWire.val)
                   , simtNestLevel = (nestLevel + nestInc) - nestDec
                   , simtRetry = retryWire.val
                   }

--- a/src/Pebbles/Pipeline/SIMT.hs
+++ b/src/Pebbles/Pipeline/SIMT.hs
@@ -182,8 +182,6 @@ makeSIMTPipeline c inputs =
     warpId5 :: Reg (Bit t_logWarps) <- makeReg dontCare
 
     -- Thread state, for each stage
-    state2 :: Reg (SIMTThreadState t_logInstrs t_logMaxNestLevel) <-
-      makeReg dontCare
     state3 :: Reg (SIMTThreadState t_logInstrs t_logMaxNestLevel) <-
       makeReg dontCare
     state4 :: Reg (SIMTThreadState t_logInstrs t_logMaxNestLevel) <-
@@ -510,7 +508,7 @@ makeSIMTPipeline c inputs =
                 suspMask!(warpId5.val) <== true
 
             -- Writeback stage
-            if resultWire.active.old
+            if delay false (resultWire.active)
               then do
                 let idx = (warpId5.val.old, instr5.val.dst.old)
                 let value = resultWire.val.old

--- a/src/Pebbles/Pipeline/SIMT.hs
+++ b/src/Pebbles/Pipeline/SIMT.hs
@@ -106,7 +106,9 @@ data SIMTThreadState t_logInstrs t_logMaxNestLevel =
     simtPC :: Bit t_logInstrs
     -- ^ Program counter
   , simtNestLevel :: Bit t_logMaxNestLevel
-    -- ^ Function call depth (smaller is deeper)
+    -- ^ SIMT divergence nesting level
+  , simtRetry :: Bit 1
+    -- ^ The last thing this thread did was a retry
   }
   deriving (Generic, Bits)
 
@@ -239,6 +241,7 @@ makeSIMTPipeline c inputs =
               SIMTThreadState {
                 simtPC = start.val
               , simtNestLevel = 0
+              , simtRetry = false
               }
         sequence_ [ store stateMem (warpIdCounter.val) initState
                   | stateMem <- stateMems ]
@@ -311,8 +314,11 @@ makeSIMTPipeline c inputs =
     -- For timing, we split this stage over several cycles
     let stage1Substages = 2
 
-    -- Active threads are those with the max nesting level,
-    let maxOf a b = if a.simtNestLevel .>. b.simtNestLevel then a else b
+    -- Active threads are those with the max nesting level
+    -- On a tie, favour instructions undergoing a retry
+    let maxOf a b =
+          if (a.simtNestLevel # a.simtRetry) .>.
+             (b.simtNestLevel # b.simtRetry) then a else b
     let state2 = pipelinedTree1 stage1Substages maxOf
                    [mem.out | mem <- stateMems]
 
@@ -332,8 +338,9 @@ makeSIMTPipeline c inputs =
       activeMask3 <== activeMask
 
       -- Assert that at least one thread in the warp must be active
-      dynamicAssert (activeList.orList)
-        "SIMT pipeline error: no active threads in warp"
+      when go2 do
+        dynamicAssert (activeList.orList)
+          "SIMT pipeline error: no active threads in warp"
 
       -- Issue load to instruction memory
       load instrMem (state2.simtPC)
@@ -477,22 +484,25 @@ makeSIMTPipeline c inputs =
               -- Trigger execute stage
               execStage.execute
 
-              -- Only update PC if not retrying
+              -- Update thread state
+              let nestInc = isSIMTPush.zeroExtendCast
+              let nestDec = isSIMTPop.zeroExtendCast
+              let nestLevel = state5.val.simtNestLevel
+              dynamicAssert (isSIMTPop .==>. nestLevel .!=. 0)
+                  "SIMT pipeliene: SIMT nest level underflow"
+              dynamicAssert (isSIMTPush .==>. nestLevel .!=. ones)
+                  "SIMT pipeliene: SIMT nest level overflow"
+              store stateMem (warpId5.val)
+                SIMTThreadState {
+                    -- Only update PC if not retrying
+                    simtPC = retryWire.val.inv ?
+                      (pcNextWire.val, state5.val.simtPC)
+                  , simtNestLevel = (nestLevel + nestInc) - nestDec
+                  , simtRetry = retryWire.val
+                  }
+
+              -- Increment instruction count
               when (retryWire.val.inv) do
-                -- Compute new call depth increment
-                let inc = isSIMTPush.zeroExtendCast
-                let dec = isSIMTPop.zeroExtendCast
-                let nestLevel = state5.val.simtNestLevel
-                dynamicAssert (isSIMTPop .==>. nestLevel .!=. 0)
-                    "SIMT pipeliene: SIMT nest level underflow"
-                dynamicAssert (isSIMTPush .==>. nestLevel .!=. ones)
-                    "SIMT pipeliene: SIMT nest level overflow"
-                store stateMem (warpId5.val)
-                  SIMTThreadState {
-                      simtPC = pcNextWire.val
-                    , simtNestLevel = (nestLevel + inc) - dec
-                    }
-                -- Increment instruction count
                 incInstrCount <== true
 
               -- Update suspension bits

--- a/test/test.sh
+++ b/test/test.sh
@@ -105,7 +105,7 @@ if [ "$TestSim" != "" ]; then
   echo -n "Starting simulator: "
   pushd . > /dev/null
   cd ../sim
-  ./sim &
+  ./sim +verilator+rand+reset+2 &
   SIM_PID=$!
   sleep 1
   popd > /dev/null


### PR DESCRIPTION
* SameAddress coalescing logic is now shared between DRAM and SRAM path.
* SameAddress coalescing on SRAM path now works better in the presence of inactive threads.
* Moved from DDR4A to DDR4B on the DE10-Pro.
* Various small fixes.